### PR TITLE
Make EJS detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-*.ejs -linguist-detectable
-*.ejs linguist-detectable=false
-*.ejs linguist-documentation=false
+


### PR DESCRIPTION
EJS is detectable on the blog, and, to keep consistency, it should be that way here as well. 